### PR TITLE
Add test suite: 86 tests covering core business logic

### DIFF
--- a/t/00_mock_sanity.t
+++ b/t/00_mock_sanity.t
@@ -1,0 +1,32 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 8;
+
+use lib 't/lib';
+use MockLMS;
+
+# Prefs
+my $prefs = Slim::Utils::Prefs::preferences('plugin.tidal');
+ok($prefs, 'preferences() returns object');
+
+$prefs->set('quality', 'LOSSLESS');
+is($prefs->get('quality'), 'LOSSLESS', 'prefs get/set works');
+
+$prefs->remove('quality');
+is($prefs->get('quality'), undef, 'prefs remove works');
+
+# Cache
+my $cache = Slim::Utils::Cache->new();
+ok($cache, 'Cache->new returns object');
+
+$cache->set('key1', 'val1', 3600);
+is($cache->get('key1'), 'val1', 'cache get/set works');
+
+$cache->remove('key1');
+is($cache->get('key1'), undef, 'cache remove works');
+
+# Logger
+my $log = Slim::Utils::Log::logger('plugin.tidal');
+ok($log, 'logger() returns object');
+ok(!$log->is_debug, 'is_debug returns false');

--- a/t/10_api_media_info.t
+++ b/t/10_api_media_info.t
@@ -1,0 +1,72 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 24;
+
+use lib 't/lib';
+use MockLMS;
+use Plugins::TIDAL::API;
+
+# --- LOSSLESS track (default quality=LOSSLESS, DASH off, Atmos off) ---
+MockLMS::reset_prefs('plugin.tidal', quality => 'LOSSLESS', enableDASH => 0, enableAtmos => 0);
+{
+    my $item = { mediaMetadata => { tags => ['LOSSLESS'] } };
+    my $r = Plugins::TIDAL::API::getMediaInfo($item);
+    is($r->{format},      'flc',   'LOSSLESS: format=flc');
+    is($r->{media_tag},   '[H]',   'LOSSLESS: media_tag=[H]');
+    is($r->{sample_rate}, 44100,   'LOSSLESS: sample_rate=44100');
+    is($r->{sample_size}, 16,      'LOSSLESS: sample_size=16');
+    is($r->{channels},    2,       'LOSSLESS: channels=2');
+}
+
+# --- HIRES_LOSSLESS with DASH enabled ---
+MockLMS::reset_prefs('plugin.tidal', quality => 'LOSSLESS', enableDASH => 1, enableAtmos => 0);
+{
+    my $item = { mediaMetadata => { tags => ['LOSSLESS', 'HIRES_LOSSLESS'] } };
+    my $r = Plugins::TIDAL::API::getMediaInfo($item);
+    is($r->{format},      'mpd',   'HIRES+DASH: format=mpd');
+    is($r->{media_tag},   '[M]',   'HIRES+DASH: media_tag=[M]');
+    is($r->{sample_rate}, 48000,   'HIRES+DASH: sample_rate=48000');
+    is($r->{sample_size}, 24,      'HIRES+DASH: sample_size=24');
+}
+
+# --- DOLBY_ATMOS with Atmos enabled ---
+MockLMS::reset_prefs('plugin.tidal', quality => 'LOSSLESS', enableDASH => 0, enableAtmos => 1);
+{
+    my $item = { mediaMetadata => { tags => ['DOLBY_ATMOS'] } };
+    my $r = Plugins::TIDAL::API::getMediaInfo($item);
+    is($r->{format},      'mp4',   'Atmos: format=mp4');
+    is($r->{media_tag},   '[A]',   'Atmos: media_tag=[A]');
+    is($r->{sample_rate}, 48000,   'Atmos: sample_rate=48000');
+    is($r->{sample_size}, 24,      'Atmos: sample_size=24');
+    is($r->{channels},    6,       'Atmos: channels=6');
+}
+
+# --- HIRES_LOSSLESS with DASH disabled falls through to LOSSLESS ---
+MockLMS::reset_prefs('plugin.tidal', quality => 'LOSSLESS', enableDASH => 0, enableAtmos => 0);
+{
+    my $item = { mediaMetadata => { tags => ['LOSSLESS', 'HIRES_LOSSLESS'] } };
+    my $r = Plugins::TIDAL::API::getMediaInfo($item);
+    is($r->{format},    'flc',   'HIRES+DASH disabled: falls back to flc');
+    is($r->{media_tag}, '[H]',   'HIRES+DASH disabled: media_tag=[H]');
+}
+
+# --- Missing tags (mediaMetadata => {tags => undef}) ---
+{
+    my $item = { mediaMetadata => { tags => undef } };
+    my $r;
+    ok(eval { $r = Plugins::TIDAL::API::getMediaInfo($item); 1 }, 'undef tags: no crash');
+    is($r->{format}, 'flc', 'undef tags: returns default format');
+}
+
+# --- Empty tags array ---
+{
+    my $item = { mediaMetadata => { tags => [] } };
+    my $r;
+    ok(eval { $r = Plugins::TIDAL::API::getMediaInfo($item); 1 }, 'empty tags: no crash');
+    is($r->{format},    'flc',   'empty tags: default format=flc');
+    is($r->{media_tag}, '[H]',   'empty tags: default media_tag=[H]');
+    is($r->{sample_rate}, 44100, 'empty tags: default sample_rate=44100');
+    is($r->{sample_size}, 16,    'empty tags: default sample_size=16');
+    is($r->{channels},    2,     'empty tags: default channels=2');
+}

--- a/t/11_api_type_of_item.t
+++ b/t/11_api_type_of_item.t
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 9;
+
+use lib 't/lib';
+use MockLMS;
+use Plugins::TIDAL::API;
+
+MockLMS::reset_prefs('plugin.tidal', quality => 'LOSSLESS', enableDASH => 0, enableAtmos => 0);
+
+# --- Album ---
+{
+    my $item = { type => 'ALBUM', releaseDate => '2024-01-01', numberOfTracks => 12 };
+    is(Plugins::TIDAL::API->typeOfItem($item), 'album', 'ALBUM type hash => album');
+}
+
+# --- Track ---
+{
+    my $item = { duration => 240 };
+    is(Plugins::TIDAL::API->typeOfItem($item), 'track', 'duration-only hash => track');
+}
+
+# --- Artist ---
+{
+    my $item = { name => 'Test Artist' };
+    is(Plugins::TIDAL::API->typeOfItem($item), 'artist', 'name-only hash => artist');
+}
+
+# --- Playlist ---
+{
+    my $item = { type => 'USER', numberOfTracks => 5, created => '2024-01-01' };
+    is(Plugins::TIDAL::API->typeOfItem($item), 'playlist', 'USER type with numberOfTracks+created => playlist');
+}
+
+# --- Undef input ---
+{
+    is(Plugins::TIDAL::API->typeOfItem(undef), '', 'undef input => empty string');
+}
+
+# --- Empty hash: no type, no duration, no name => falls through to track ---
+{
+    my $item = {};
+    is(Plugins::TIDAL::API->typeOfItem($item), 'track', 'empty hash => track (duration check: !type)');
+}
+
+# --- String input (non-ref) ---
+{
+    is(Plugins::TIDAL::API->typeOfItem('foo'), '', 'string input => empty string');
+}
+
+# --- EP type ---
+{
+    my $item = { type => 'EP', releaseDate => '2023-05-01', numberOfTracks => 4 };
+    is(Plugins::TIDAL::API->typeOfItem($item), 'album', 'EP type => album');
+}
+
+# --- SINGLE type ---
+{
+    my $item = { type => 'SINGLE', releaseDate => '2024-03-01', numberOfTracks => 1 };
+    is(Plugins::TIDAL::API->typeOfItem($item), 'album', 'SINGLE type => album');
+}

--- a/t/20_async_filter_pipeline.t
+++ b/t/20_async_filter_pipeline.t
@@ -1,0 +1,165 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 23;
+use Scalar::Util qw(reftype);
+
+use lib 't/lib';
+use MockLMS;
+use Plugins::TIDAL::API::Async;
+
+MockLMS::reset_prefs('plugin.tidal', quality => 'LOSSLESS', enableDASH => 1, enableAtmos => 0, preferExplicit => 0);
+
+sub make_album {
+    my (%args) = @_;
+    return {
+        artist        => { id => $args{artist_id} || 1 },
+        title         => $args{title} || 'Test Album',
+        numberOfTracks => $args{tracks} || 10,
+        explicit      => $args{explicit} || 0,
+        mediaMetadata => { tags => $args{tags} || ['LOSSLESS'] },
+    };
+}
+
+# =============================================================================
+# _tagAlbums
+# =============================================================================
+
+# LOSSLESS always gets rank 1
+{
+    my $album = make_album(tags => ['LOSSLESS']);
+    my $tagged = Plugins::TIDAL::API::Async::_tagAlbums([$album]);
+    is(scalar @$tagged, 1, '_tagAlbums: LOSSLESS album kept');
+    is($tagged->[0]{_quality_rank}, 1, '_tagAlbums: LOSSLESS rank=1');
+}
+
+# HIRES_LOSSLESS with DASH enabled gets rank 2
+{
+    my $album = make_album(tags => ['LOSSLESS', 'HIRES_LOSSLESS']);
+    my $tagged = Plugins::TIDAL::API::Async::_tagAlbums([$album]);
+    is(scalar @$tagged, 1, '_tagAlbums: HIRES_LOSSLESS+DASH kept');
+    is($tagged->[0]{_quality_rank}, 2, '_tagAlbums: HIRES_LOSSLESS+DASH rank=2');
+}
+
+# HIRES_LOSSLESS with DASH disabled gets rank 0 (excluded)
+{
+    MockLMS::reset_prefs('plugin.tidal', quality => 'LOSSLESS', enableDASH => 0, enableAtmos => 0);
+    my $album = make_album(tags => ['LOSSLESS', 'HIRES_LOSSLESS']);
+    my $tagged = Plugins::TIDAL::API::Async::_tagAlbums([$album]);
+    # HIRES_LOSSLESS with DASH off: media_tag=[H] so rank=1, not excluded
+    # (it falls through to LOSSLESS CD quality)
+    is($tagged->[0]{_quality_rank}, 1, '_tagAlbums: HIRES_LOSSLESS+DASH disabled => rank=1 (CD)');
+    MockLMS::reset_prefs('plugin.tidal', quality => 'LOSSLESS', enableDASH => 1, enableAtmos => 0, preferExplicit => 0);
+}
+
+# Album with no LOSSLESS/DOLBY_ATMOS tag is excluded entirely
+{
+    my $album = make_album(tags => ['HIGH']);
+    my $tagged = Plugins::TIDAL::API::Async::_tagAlbums([$album]);
+    is(scalar @$tagged, 0, '_tagAlbums: no LOSSLESS tag => excluded');
+}
+
+# =============================================================================
+# _groupByFingerprint
+# =============================================================================
+
+{
+    my $a1 = { album => make_album(title => 'Alpha'), _quality_rank => 1, _fingerprint => '1:Alpha:10' };
+    my $a2 = { album => make_album(title => 'Beta'),  _quality_rank => 1, _fingerprint => '1:Beta:10'  };
+    my $a3 = { album => make_album(title => 'Alpha'), _quality_rank => 2, _fingerprint => '1:Alpha:10' };
+
+    my $result = Plugins::TIDAL::API::Async::_groupByFingerprint([$a1, $a2, $a3]);
+    ok(exists $result->{groups},                     '_groupByFingerprint: has groups key');
+    ok(exists $result->{order},                      '_groupByFingerprint: has order key');
+    is(scalar @{ $result->{order} }, 2,              '_groupByFingerprint: 2 distinct fingerprints');
+    is($result->{order}->[0], '1:Alpha:10',          '_groupByFingerprint: insertion order preserved (Alpha first)');
+    is(scalar @{ $result->{groups}{'1:Alpha:10'} }, 2, '_groupByFingerprint: Alpha group has 2 entries');
+}
+
+# =============================================================================
+# _selectPreferred
+# =============================================================================
+
+{
+    # rank 1 and rank 2 same fingerprint => only rank 2 kept
+    my $fp = '1:Test:10';
+    my $a_low  = { album => make_album(), _quality_rank => 1, _fingerprint => $fp };
+    my $a_high = { album => make_album(), _quality_rank => 2, _fingerprint => $fp };
+    my $groups = Plugins::TIDAL::API::Async::_groupByFingerprint([$a_low, $a_high]);
+    my $selected = Plugins::TIDAL::API::Async::_selectPreferred($groups);
+    my ($sel_groups, $sel_order) = @{$selected}{qw(groups order)};
+    is(scalar @{$sel_groups->{$fp}}, 1, '_selectPreferred: only highest rank kept');
+    is($sel_groups->{$fp}->[0]{_quality_rank}, 2, '_selectPreferred: kept item has rank 2');
+}
+
+{
+    # same rank => both kept
+    my $fp = '1:Test:10';
+    my $a1 = { album => make_album(explicit => 1), _quality_rank => 1, _fingerprint => $fp };
+    my $a2 = { album => make_album(explicit => 0), _quality_rank => 1, _fingerprint => $fp };
+    my $groups = Plugins::TIDAL::API::Async::_groupByFingerprint([$a1, $a2]);
+    my $selected = Plugins::TIDAL::API::Async::_selectPreferred($groups);
+    my ($sel_groups) = @{$selected}{qw(groups)};
+    is(scalar @{$sel_groups->{$fp}}, 2, '_selectPreferred: same rank keeps both');
+}
+
+# =============================================================================
+# _filterExplicit
+# =============================================================================
+
+{
+    # preferExplicit=0, both versions exist => clean returned
+    my $fp = '1:Test:10';
+    my $explicit = { album => make_album(explicit => 1), _quality_rank => 1, _fingerprint => $fp };
+    my $clean    = { album => make_album(explicit => 0), _quality_rank => 1, _fingerprint => $fp };
+    my $data = Plugins::TIDAL::API::Async::_groupByFingerprint([$explicit, $clean]);
+    my $result = Plugins::TIDAL::API::Async::_filterExplicit($data, 0);
+    is(scalar @$result, 1, '_filterExplicit(prefer clean): one result');
+    is($result->[0]{explicit}, 0, '_filterExplicit(prefer clean): clean version returned');
+}
+
+{
+    # preferExplicit=1, both versions exist => explicit returned
+    my $fp = '1:Test:10';
+    my $explicit = { album => make_album(explicit => 1), _quality_rank => 1, _fingerprint => $fp };
+    my $clean    = { album => make_album(explicit => 0), _quality_rank => 1, _fingerprint => $fp };
+    my $data = Plugins::TIDAL::API::Async::_groupByFingerprint([$explicit, $clean]);
+    my $result = Plugins::TIDAL::API::Async::_filterExplicit($data, 1);
+    is(scalar @$result, 1, '_filterExplicit(prefer explicit): one result');
+    is($result->[0]{explicit}, 1, '_filterExplicit(prefer explicit): explicit version returned');
+}
+
+{
+    # only one version exists => returned regardless of preference
+    my $fp = '1:Test:10';
+    my $only = { album => make_album(explicit => 1), _quality_rank => 1, _fingerprint => $fp };
+    my $data = Plugins::TIDAL::API::Async::_groupByFingerprint([$only]);
+
+    my $r0 = Plugins::TIDAL::API::Async::_filterExplicit($data, 0);
+    is(scalar @$r0, 1,               '_filterExplicit(only explicit, prefer clean): still returned');
+
+    my $r1 = Plugins::TIDAL::API::Async::_filterExplicit($data, 1);
+    is(scalar @$r1, 1,               '_filterExplicit(only explicit, prefer explicit): returned');
+}
+
+# =============================================================================
+# Integration: full pipeline via _filterAlbums mock via _tagAlbums+pipeline
+# =============================================================================
+
+{
+    # DASH enabled. Same title/artist/tracks in [H] (LOSSLESS) and [M] (HIRES_LOSSLESS).
+    # Pipeline should keep only [M] version.
+    MockLMS::reset_prefs('plugin.tidal', quality => 'LOSSLESS', enableDASH => 1, enableAtmos => 0, preferExplicit => 0);
+
+    my $lossless = make_album(artist_id => 5, title => 'Big Album', tracks => 12, tags => ['LOSSLESS']);
+    my $hires    = make_album(artist_id => 5, title => 'Big Album', tracks => 12, tags => ['LOSSLESS', 'HIRES_LOSSLESS']);
+
+    my $tagged   = Plugins::TIDAL::API::Async::_tagAlbums([$lossless, $hires]);
+    my $groups   = Plugins::TIDAL::API::Async::_groupByFingerprint($tagged);
+    my $selected = Plugins::TIDAL::API::Async::_selectPreferred($groups);
+    my $final    = Plugins::TIDAL::API::Async::_filterExplicit($selected, 0);
+
+    is(scalar @$final, 1, 'integration: only one album returned after pipeline');
+    is($final->[0]{mediaMetadata}{tags}[0], 'LOSSLESS',         'integration: result has LOSSLESS tag');
+    ok((grep { $_ eq 'HIRES_LOSSLESS' } @{$final->[0]{mediaMetadata}{tags}}), 'integration: result is the HIRES version');
+}

--- a/t/30_importer_prepare_track.t
+++ b/t/30_importer_prepare_track.t
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 9;
+
+use lib 't/lib';
+use MockLMS;
+
+# Stub API::Sync before loading Importer (only needed at runtime, but safe to stub early)
+BEGIN {
+    package Plugins::TIDAL::API::Sync;
+    sub getTrackData { return undef }
+    $INC{'Plugins/TIDAL/API/Sync.pm'} = 1;
+}
+
+use Plugins::TIDAL::API;
+use Plugins::TIDAL::Importer;
+
+MockLMS::reset_prefs('plugin.tidal', quality => 'LOSSLESS', enableDASH => 0, enableAtmos => 0);
+MockLMS::reset_prefs('server', splitList => ',');
+
+my $album = {
+    title          => 'Test Album',
+    id             => 100,
+    releaseDate    => '2024-06-15',
+    cover          => 'http://example.com/cover.jpg',
+    type           => 'ALBUM',
+    numberOfVolumes => 1,
+    added          => 1700000000,
+};
+
+my $track = {
+    id            => 12345,
+    title         => 'Test Track',
+    duration      => 240,
+    artist        => { id => 1, name => 'Test Artist' },
+    artists       => [{ id => 1, name => 'Test Artist', type => 'MAIN' }],
+    tracknum      => 3,
+    disc          => 1,
+    bpm           => 120,
+    replayGain    => -6.5,
+    peak          => 0.95,
+    mediaMetadata => { tags => ['LOSSLESS'] },
+};
+
+my $result = Plugins::TIDAL::Importer::_prepareTrack($album, $track);
+
+ok(defined $result,                                         '_prepareTrack returns a result');
+like($result->{url},           qr{tidal://12345\.flc},     'url matches tidal://12345.flc');
+is($result->{CONTENT_TYPE},    'flc',                      'CONTENT_TYPE is flc');
+is($result->{LOSSLESS},        1,                          'LOSSLESS is 1');
+is($result->{TITLE},           'Test Track',               'TITLE is correct');
+is($result->{YEAR},            '2024',                     'YEAR extracted from releaseDate');
+is($result->{BPM},             120,                        'BPM is 120');
+is($result->{REPLAYGAIN_TRACK_GAIN}, -6.5,                 'REPLAYGAIN_TRACK_GAIN is -6.5');
+is($result->{SECS},            240,                        'SECS (duration) is 240');

--- a/t/40_plugin_render.t
+++ b/t/40_plugin_render.t
@@ -1,0 +1,79 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 13;
+
+use lib 't/lib';
+use MockLMS;
+use Plugins::TIDAL::Plugin;
+
+MockLMS::reset_prefs('plugin.tidal', quality => 'LOSSLESS', enableDASH => 0, enableAtmos => 0);
+
+# =============================================================================
+# _renderAlbum
+# =============================================================================
+
+my $item = {
+    id             => 100,
+    title          => 'Test Album',
+    releaseDate    => '2024-06-15',
+    explicit       => 0,
+    numberOfTracks => 10,
+    artist         => { id => 1, name => 'Test Artist' },
+    mediaMetadata  => { tags => ['LOSSLESS'] },
+};
+
+my $result = Plugins::TIDAL::Plugin::_renderAlbum($item, 0);
+
+ok(defined $result,                                     '_renderAlbum returns a result');
+like($result->{name}, qr/2024/,                         'name includes release year');
+like($result->{name}, qr/\[H\]/,                        'name includes quality tag [H]');
+unlike($result->{name}, qr/\[E\]/,                      'no [E] for non-explicit album');
+
+# Source title NOT mutated
+is($item->{title}, 'Test Album',                        'source title not mutated after _renderAlbum');
+
+# With explicit flag
+my $explicit_item = {
+    %$item,
+    title    => 'Test Album',
+    explicit => 1,
+};
+my $explicit_result = Plugins::TIDAL::Plugin::_renderAlbum($explicit_item, 0);
+like($explicit_result->{name}, qr/\[E\]/,               'explicit album name includes [E]');
+
+# Source title NOT mutated after explicit test
+is($explicit_item->{title}, 'Test Album',               'source title not mutated after explicit test');
+
+# With addArtistToTitle
+my $artist_result = Plugins::TIDAL::Plugin::_renderAlbum($item, 1);
+like($artist_result->{name}, qr/Test Artist/,            'addArtistToTitle: name includes artist');
+
+# Source title not mutated after artist test
+is($item->{title}, 'Test Album',                        'source title not mutated after artist test');
+
+# =============================================================================
+# _renderTrack
+# =============================================================================
+
+my $track_item = {
+    id            => 12345,
+    title         => 'Test Track',
+    duration      => 240,
+    explicit      => 0,
+    artist        => { id => 1, name => 'Test Artist' },
+    mediaMetadata => { tags => ['LOSSLESS'] },
+};
+
+my $track_result = Plugins::TIDAL::Plugin::_renderTrack($track_item, 0);
+
+ok(defined $track_result,                               '_renderTrack returns a result');
+like($track_result->{url}, qr{tidal://12345\.flc},      'url matches tidal://12345.flc');
+is($track_result->{type},  'audio',                     'type is audio');
+
+# explicit track test
+my $explicit_track = { %$track_item, title => 'Test Track', explicit => 1 };
+Plugins::TIDAL::Plugin::_renderTrack($explicit_track, 0);
+
+# Source title NOT mutated after explicit test
+is($track_item->{title}, 'Test Track',                  'track source title not mutated after explicit test');

--- a/t/lib/MockLMS.pm
+++ b/t/lib/MockLMS.pm
@@ -1,0 +1,274 @@
+package MockLMS;
+
+# Lightweight mocks for LMS dependencies so we can test plugin code in isolation.
+# Load this BEFORE any Plugins::TIDAL::* modules:
+#   use lib 't/lib';
+#   use MockLMS;
+
+use strict;
+use warnings;
+
+# --- CPAN module stubs (normally provided by LMS runtime) ---
+BEGIN {
+	# Exporter::Lite — just re-export via standard Exporter
+	unless (eval { require Exporter::Lite; 1 }) {
+		package Exporter::Lite;
+		sub import {
+			my $class = shift;
+			my $caller = caller;
+			# Make the calling package use standard Exporter
+			no strict 'refs';
+			push @{"${caller}::ISA"}, 'Exporter' unless grep { $_ eq 'Exporter' } @{"${caller}::ISA"};
+		}
+		$INC{'Exporter/Lite.pm'} = 1;
+	}
+
+	# JSON::XS::VersionOneAndTwo — provide from_json/to_json via JSON::PP
+	unless (eval { require JSON::XS::VersionOneAndTwo; 1 }) {
+		package JSON::XS::VersionOneAndTwo;
+		require JSON::PP;
+		sub import {
+			my $caller = caller;
+			no strict 'refs';
+			*{"${caller}::from_json"} = \&JSON::PP::decode_json;
+			*{"${caller}::to_json"} = \&JSON::PP::encode_json;
+		}
+		$INC{'JSON/XS/VersionOneAndTwo.pm'} = 1;
+	}
+
+	# Data::URIEncode
+	unless (eval { require Data::URIEncode; 1 }) {
+		package Data::URIEncode;
+		use Exporter 'import';
+		our @EXPORT_OK = qw(complex_to_query);
+		sub complex_to_query { return '' }
+		$INC{'Data/URIEncode.pm'} = 1;
+	}
+
+	# Async::Util
+	unless (eval { require Async::Util; 1 }) {
+		package Async::Util;
+		$INC{'Async/Util.pm'} = 1;
+	}
+
+	# Date::Parse
+	unless (eval { require Date::Parse; 1 }) {
+		package Date::Parse;
+		use Exporter 'import';
+		our @EXPORT_OK = qw(str2time);
+		sub str2time { return time() }
+		$INC{'Date/Parse.pm'} = 1;
+	}
+
+	# URI::Escape
+	unless (eval { require URI::Escape; 1 }) {
+		package URI::Escape;
+		use Exporter 'import';
+		our @EXPORT_OK = qw(uri_escape_utf8 uri_escape uri_unescape);
+		sub uri_escape_utf8 { return $_[0] }
+		sub uri_escape { return $_[0] }
+		sub uri_unescape { return $_[0] }
+		$INC{'URI/Escape.pm'} = 1;
+	}
+
+	# Scalar::Util and MIME::Base64 are core — no stubs needed
+
+	# HTTP::Status (for Settings.pm)
+	unless (eval { require HTTP::Status; 1 }) {
+		package HTTP::Status;
+		use Exporter 'import';
+		our @EXPORT_OK = qw(RC_MOVED_TEMPORARILY);
+		sub RC_MOVED_TEMPORARILY { 302 }
+		$INC{'HTTP/Status.pm'} = 1;
+	}
+
+	# Slim modules that get use'd at compile time by various plugin modules
+	# Slim base classes — register in %INC, provide stubs for methods they offer
+	for my $stub (
+		'Slim::Networking::SimpleAsyncHTTP',
+		'Slim::Networking::SimpleSyncHTTP',
+		'Slim::Utils::Accessor',
+		'Slim::Utils::Misc',
+		'Slim::Utils::Timers',
+		'Slim::Utils::Progress',
+		'Slim::Music::Import',
+		'Slim::Player::Protocols::HTTPS',
+		'Slim::Player::ProtocolHandlers',
+		'Slim::Plugin::OPMLBased',
+		'Slim::Plugin::OnlineLibraryBase',
+		'Slim::Web::Settings',
+		'Slim::Web::HTTP',
+		'Slim::Utils::Scanner::Remote',
+		'Slim::Music::Info',
+		'Slim::Player::ReplayGain',
+		'Slim::Control::Request',
+	) {
+		(my $file = $stub) =~ s|::|/|g;
+		$file .= '.pm';
+		$INC{$file} = 1;
+	}
+
+	# Give base classes a version so `use base` doesn't complain about empty packages
+	for my $base (qw(
+		Slim::Plugin::OPMLBased
+		Slim::Plugin::OnlineLibraryBase
+		Slim::Player::Protocols::HTTPS
+		Slim::Web::Settings
+	)) {
+		no strict 'refs';
+		${"${base}::VERSION"} = '0.01';
+	}
+	no strict 'refs';
+	*{'Slim::Utils::Misc::getTempDir'} = sub { '/tmp' };
+	*{'Slim::Utils::Misc::fileURLFromPath'} = sub { "file://$_[0]" };
+	*{'Slim::Utils::Accessor::mk_accessor'} = sub { };
+	*{'Slim::Player::ProtocolHandlers::registerURLHandler'} = sub { };
+	*{'Slim::Player::ProtocolHandlers::registerHandler'} = sub { };
+	*{'Slim::Plugin::OPMLBased::initPlugin'} = sub { };
+	*{'Slim::Plugin::OPMLBased::_pluginDataFor'} = sub { '' };
+	*{'Slim::Web::HTTP::filltemplatefile'} = sub { '' };
+	*{'Slim::Music::Info::setBitrate'} = sub { };
+	*{'Slim::Music::Info::setDuration'} = sub { };
+}
+
+# --- Slim::Utils::Prefs ---
+BEGIN {
+	package Slim::Utils::Prefs;
+	my %stores;
+
+	sub new {
+		my ($class, $namespace) = @_;
+		$stores{$namespace} ||= {};
+		return bless { ns => $namespace, data => $stores{$namespace} }, $class;
+	}
+
+	sub get {
+		my ($self, $key) = @_;
+		return $self->{data}{$key};
+	}
+
+	sub set {
+		my ($self, $key, $val) = @_;
+		$self->{data}{$key} = $val;
+	}
+
+	sub remove {
+		my ($self, @keys) = @_;
+		delete $self->{data}{$_} for @keys;
+	}
+
+	sub init {
+		my ($self, $defaults) = @_;
+		for my $k (keys %$defaults) {
+			$self->{data}{$k} = $defaults->{$k} unless defined $self->{data}{$k};
+		}
+	}
+
+	sub migrate { 1 }
+	sub setChange { }
+	sub setValidate { }
+	sub client { $_[0] }
+
+	sub preferences {
+		my $ns = $_[0] || 'plugin.tidal';
+		return Slim::Utils::Prefs->new($ns);
+	}
+
+	sub import {
+		my $caller = caller;
+		no strict 'refs';
+		*{"${caller}::preferences"} = \&preferences;
+	}
+
+	$INC{'Slim/Utils/Prefs.pm'} = 1;
+}
+
+# --- Slim::Utils::Cache ---
+BEGIN {
+	package Slim::Utils::Cache;
+
+	sub new {
+		my ($class) = @_;
+		return bless { data => {} }, $class;
+	}
+
+	sub get {
+		my ($self, $key) = @_;
+		return $self->{data}{$key};
+	}
+
+	sub set {
+		my ($self, $key, $val, $ttl) = @_;
+		$self->{data}{$key} = $val;
+	}
+
+	sub remove {
+		my ($self, $key) = @_;
+		delete $self->{data}{$key};
+	}
+
+	$INC{'Slim/Utils/Cache.pm'} = 1;
+}
+
+# --- Slim::Utils::Log ---
+BEGIN {
+	package Slim::Utils::Log;
+
+	sub new { return bless {}, $_[0] }
+	sub addLogCategory { return Slim::Utils::Log->new() }
+	sub logger { return Slim::Utils::Log->new() }
+
+	sub import {
+		my $caller = caller;
+		no strict 'refs';
+		*{"${caller}::logger"} = \&logger;
+	}
+
+	for my $method (qw(debug info warn error is_debug is_info is_warn is_error logBacktrace)) {
+		no strict 'refs';
+		*{"Slim::Utils::Log::$method"} = sub { 0 };
+	}
+
+	$INC{'Slim/Utils/Log.pm'} = 1;
+}
+
+# --- Slim::Utils::Strings ---
+BEGIN {
+	package Slim::Utils::Strings;
+	require Exporter;
+	our @ISA = ('Exporter');
+	our @EXPORT_OK = qw(string cstring);
+
+	sub string { return $_[0] }
+	sub cstring { return $_[1] || $_[0] }
+
+	$INC{'Slim/Utils/Strings.pm'} = 1;
+}
+
+# --- Slim::Web::HTTP::CSRF ---
+BEGIN {
+	package Slim::Web::HTTP::CSRF;
+	sub protectName { return $_[1] }
+	sub protectURI { return $_[1] }
+	$INC{'Slim/Web/HTTP/CSRF.pm'} = 1;
+}
+
+# --- Stub out main:: constants used in compile-time guards ---
+BEGIN {
+	no warnings 'once';
+	*main::SCANNER = sub { 0 };
+	*main::DEBUGLOG = sub { 0 };
+	*main::INFOLOG = sub { 0 };
+	*main::WEBUI = sub { 0 };
+}
+
+# --- Helper to reset prefs between tests ---
+sub reset_prefs {
+	my ($ns, %vals) = @_;
+	$ns ||= 'plugin.tidal';
+	my $prefs = Slim::Utils::Prefs->new($ns);
+	%{$prefs->{data}} = %vals;
+	return $prefs;
+}
+
+1;

--- a/t/lib/Plugins/TIDAL/API
+++ b/t/lib/Plugins/TIDAL/API
@@ -1,0 +1,1 @@
+/home/fish/code/lms-plugin-tidal/API

--- a/t/lib/Plugins/TIDAL/API.pm
+++ b/t/lib/Plugins/TIDAL/API.pm
@@ -1,0 +1,1 @@
+/home/fish/code/lms-plugin-tidal/API.pm

--- a/t/lib/Plugins/TIDAL/HomeExtras.pm
+++ b/t/lib/Plugins/TIDAL/HomeExtras.pm
@@ -1,0 +1,1 @@
+/home/fish/code/lms-plugin-tidal/HomeExtras.pm

--- a/t/lib/Plugins/TIDAL/Importer.pm
+++ b/t/lib/Plugins/TIDAL/Importer.pm
@@ -1,0 +1,1 @@
+/home/fish/code/lms-plugin-tidal/Importer.pm

--- a/t/lib/Plugins/TIDAL/InfoMenu.pm
+++ b/t/lib/Plugins/TIDAL/InfoMenu.pm
@@ -1,0 +1,1 @@
+/home/fish/code/lms-plugin-tidal/InfoMenu.pm

--- a/t/lib/Plugins/TIDAL/LastMix.pm
+++ b/t/lib/Plugins/TIDAL/LastMix.pm
@@ -1,0 +1,1 @@
+/home/fish/code/lms-plugin-tidal/LastMix.pm

--- a/t/lib/Plugins/TIDAL/Plugin.pm
+++ b/t/lib/Plugins/TIDAL/Plugin.pm
@@ -1,0 +1,1 @@
+/home/fish/code/lms-plugin-tidal/Plugin.pm

--- a/t/lib/Plugins/TIDAL/ProtocolHandler.pm
+++ b/t/lib/Plugins/TIDAL/ProtocolHandler.pm
@@ -1,0 +1,1 @@
+/home/fish/code/lms-plugin-tidal/ProtocolHandler.pm

--- a/t/lib/Plugins/TIDAL/Settings.pm
+++ b/t/lib/Plugins/TIDAL/Settings.pm
@@ -1,0 +1,1 @@
+/home/fish/code/lms-plugin-tidal/Settings.pm


### PR DESCRIPTION
## Summary

Add a rudimentary Perl test suite with 86 tests covering core business logic.

## What's included

**Mock layer** (`t/lib/MockLMS.pm`): Stubs all LMS runtime dependencies (Slim::Utils::Prefs, Cache, Log, etc.) so plugin code can be tested without an LMS installation. Zero external dependencies beyond core Perl + Test::More.

**Test files:**

| File | Tests | Coverage |
|------|-------|----------|
| `t/00_mock_sanity.t` | 8 | Mock layer itself |
| `t/10_api_media_info.t` | 24 | Quality tier detection, tag handling, edge cases |
| `t/11_api_type_of_item.t` | 9 | Item type pattern matching |
| `t/20_async_filter_pipeline.t` | 23 | Full _filterAlbums pipeline + integration |
| `t/30_importer_prepare_track.t` | 9 | URL format, metadata mapping, replay gain |
| `t/40_plugin_render.t` | 13 | Title construction, no-mutation verification |

## Running

```bash
prove -r t/
```

## Test plan
- [x] `prove -r t/` passes (86/86)
- [ ] Each test file runs independently
